### PR TITLE
Update Makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -18,5 +18,3 @@ serve:
 .PHONY: build
 build:
 	cd dwmkerr.com; hugo --minify
-
-.PHONY: setup serve

--- a/makefile
+++ b/makefile
@@ -3,6 +3,7 @@
 setup:
 	brew install hugo
 	hugo version
+	git submodule update --init --recursive --remote
 
 # Create a new post.
 .PHONY: newpost

--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 # Setup tools required for local development.
 setup:
 	brew install hugo
-	hugo vesion
+	hugo version
 
 # Createe a new post.
 newpost:

--- a/makefile
+++ b/makefile
@@ -1,17 +1,21 @@
 # Setup tools required for local development.
+.PHONY: setup
 setup:
 	brew install hugo
 	hugo version
 
-# Createe a new post.
+# Create a new post.
+.PHONY: newpost
 newpost:
 	cd dwmkerr.com; hugo new posts/my-first-post.md
 
 # Serve the site locally for testing.
+.PHONY: serve
 serve:
 	cd dwmkerr.com; hugo server --baseURL "http://localhost/" --buildDrafts -v --debug
 
 # Build the site.
+.PHONY: build
 build:
 	cd dwmkerr.com; hugo --minify
 


### PR DESCRIPTION
# Context

Changed the `makefile` to create a seamless set up workflow for anyone getting started.

## Changes

- Fixed a couple of typos that were present in the `makefile`
  - `make setup` failed to run
- Added `.PHONY:` to each of the `make` commands
  - If `.PHONY:` is not used, the `make` commands are treated as file targets
- Removed unnecessary `.PHONY: setup serve`
  - `make` recipes can have sequential arguments, so `make setup serve` will run `make setup` first and then run `make serve`
- Added a `git` command to update submodules
  - Themes were not installed and is necessary to display the website locally, otherwise will be presented with a blank page

I have tested these changes and I am now able to serve your website by simply running `make setup serve` without any issues.
