### PR TITLE
ci: update PR workflow with modern actions and preview deploy

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,28 +4,48 @@ name: Validate Pull Request
 on: [pull_request]
 
 jobs:
-  build-deploy:
-    runs-on: ubuntu-20.04
+  validate-pull-request:
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: true
 
     - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v2
+      uses: peaceiris/actions-hugo@v3
       with:
-        hugo-version: '0.93.0'
-        # extended: true
+        hugo-version: 'latest'
+        extended: true
 
     - name: Build
       working-directory: ./dwmkerr.com
       run: hugo --minify
 
-    - name: Deploy
-      uses: peaceiris/actions-gh-pages@v2
-      env:
-        ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-        PUBLISH_BRANCH: gh-pages
-        PUBLISH_DIR: ./dwmkerr.com/public
+  # Deploy a preview of the PR
+  # See: https://github.com/marketplace/actions/deploy-pr-preview
+  deploy-preview:
+    runs-on: ubuntu-24.04
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - name: Setup Hugo
+      uses: peaceiris/actions-hugo@v3
+      with:
+        hugo-version: 'latest'
+        extended: true
+
+    - name: Build for Preview
+      if: github.event.action != 'closed'
+      working-directory: ./dwmkerr.com
+      run: hugo --minify --baseURL "https://dwmkerr.github.io/dwmkerr.com/pr-preview/pr-${{ github.event.number }}/"
+
+    - name: Deploy preview
+      uses: rossjrw/pr-preview-action@v1
+      with:
+        source-dir: ./dwmkerr.com/public/


### PR DESCRIPTION
- Update to ubuntu-24.04
- Update actions/checkout to v4
- Update peaceiris/actions-hugo to v3 with latest Hugo
- Add PR preview deployment using rossjrw/pr-preview-action