### PR TITLE
feat: add Substack email subscribe form to posts

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Verify Hugo build before pushing
+cd dwmkerr.com && hugo --minify > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+    echo "ERROR: Hugo build failed. Fix errors before pushing."
+    cd dwmkerr.com && hugo --minify
+    exit 1
+fi

--- a/dwmkerr.com/config.toml
+++ b/dwmkerr.com/config.toml
@@ -50,10 +50,6 @@ googleAnalytics = "G-XNRSGLYJRM"
     url = "/page/about/"
     weight = 2
 
-[[menu.main]]
-    name = "Subscribe"
-    url = "/page/subscribe/"
-    weight = 3
 
 [Permalinks]
     post = "/:slug"

--- a/dwmkerr.com/config.toml
+++ b/dwmkerr.com/config.toml
@@ -50,6 +50,11 @@ googleAnalytics = "G-XNRSGLYJRM"
     url = "/page/about/"
     weight = 2
 
+[[menu.main]]
+    name = "Subscribe"
+    url = "/page/subscribe/"
+    weight = 3
+
 [Permalinks]
     post = "/:slug"
 

--- a/dwmkerr.com/config.toml
+++ b/dwmkerr.com/config.toml
@@ -26,6 +26,8 @@ googleAnalytics = "G-XNRSGLYJRM"
   bookurl = "https://amzn.to/4ho0F91"
   # Disqus shortname (disabled - shows ads on free tier)
   # disqus = "dwmkerr"
+  # Substack publication name (e.g. "dwmkerr" for dwmkerr.substack.com)
+  substack = "dwmkerr"
   author = "Dave Kerr"
   authorwebsite = "dwmkerr.com"
   avatar = "/images/avatar.jpeg"

--- a/dwmkerr.com/content/page/subscribe.md
+++ b/dwmkerr.com/content/page/subscribe.md
@@ -1,0 +1,11 @@
+---
+author: Dave Kerr
+description: "Subscribe to get new posts by email"
+draft: false
+slug: subscribe
+title: Subscribe
+---
+
+Get new posts delivered to your inbox. No spam, unsubscribe anytime.
+
+<iframe src="https://dwmkerr.substack.com/embed" width="480" height="320" style="border:1px solid #EEE; background:white;" frameborder="0" scrolling="no"></iframe>

--- a/dwmkerr.com/layouts/_default/rss.xml
+++ b/dwmkerr.com/layouts/_default/rss.xml
@@ -4,9 +4,8 @@
     <link>{{ .Permalink }}</link>
     <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
     <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
-    <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
-    <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
-    <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
+    <language>{{.}}</language>{{end}}{{ with .Site.Params.author }}
+    <managingEditor>{{.}}</managingEditor>{{end}}{{ with .Site.Copyright }}
     <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
     <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
     {{ with .OutputFormats.Get "RSS" }}
@@ -17,7 +16,6 @@
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-      {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
       <guid>{{ .Permalink }}</guid>
       <description>{{- .Content | html -}}</description>
       <category>CodeProject</category>

--- a/dwmkerr.com/layouts/_default/single.html
+++ b/dwmkerr.com/layouts/_default/single.html
@@ -30,21 +30,15 @@
     <a href="{{ . }}" target="_blank" rel="noopener">Discuss on Hacker News / Reddit</a>
   </div>
   {{ end }}
+  {{ if eq (.Type | singularize) "post" }}
   {{ with .Site.Params.substack }}
   <div class="p-article__subscribe">
     <a href="{{ absURL "page/subscribe" }}">Subscribe to get new posts by email</a>
   </div>
   {{ end }}
+  {{ end }}
   <footer>
     {{ if eq (.Type | singularize) "page" }}
-    <div>
-	    <div class="c-last-update">
-		    Last Update:
-		    <time datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" | safeHTML }}">
-			    {{ .Date.Format "Jan 2, 2006" }}
-		    </time>
-	    </div>
-    </div>
     {{ else }}
     {{ partial "comment_custom.html" . }}
     {{ with ($.Param "disqus") }}

--- a/dwmkerr.com/layouts/_default/single.html
+++ b/dwmkerr.com/layouts/_default/single.html
@@ -67,7 +67,6 @@
       </div>
     </nav>
     {{ end }}
-    {{ partial "related.html" . }}
     {{ partial "siteinfo.html" . }}
   </footer>
 </article>

--- a/dwmkerr.com/layouts/_default/single.html
+++ b/dwmkerr.com/layouts/_default/single.html
@@ -32,7 +32,7 @@
   {{ end }}
   {{ with .Site.Params.substack }}
   <div class="p-article__subscribe">
-    <a href="https://{{ . }}.substack.com/" target="_blank" rel="noopener">Subscribe to get new posts by email</a>
+    <a href="{{ absURL "page/subscribe" }}">Subscribe to get new posts by email</a>
   </div>
   {{ end }}
   <footer>

--- a/dwmkerr.com/layouts/_default/single.html
+++ b/dwmkerr.com/layouts/_default/single.html
@@ -32,8 +32,7 @@
   {{ end }}
   {{ with .Site.Params.substack }}
   <div class="p-article__subscribe">
-    <p>If you enjoyed this article, subscribe to get new posts by email.</p>
-    <iframe src="https://{{ . }}.substack.com/embed" frameborder="0" scrolling="no" class="p-article__subscribe-frame"></iframe>
+    <a href="https://{{ . }}.substack.com/" target="_blank" rel="noopener">Subscribe to get new posts by email</a>
   </div>
   {{ end }}
   <footer>

--- a/dwmkerr.com/layouts/_default/single.html
+++ b/dwmkerr.com/layouts/_default/single.html
@@ -30,6 +30,12 @@
     <a href="{{ . }}" target="_blank" rel="noopener">Discuss on Hacker News / Reddit</a>
   </div>
   {{ end }}
+  {{ with .Site.Params.substack }}
+  <div class="p-article__subscribe">
+    <p>If you enjoyed this article, subscribe to get new posts by email.</p>
+    <iframe src="https://{{ . }}.substack.com/embed" frameborder="0" scrolling="no" class="p-article__subscribe-frame"></iframe>
+  </div>
+  {{ end }}
   <footer>
     {{ if eq (.Type | singularize) "page" }}
     <div>

--- a/dwmkerr.com/layouts/_default/single.html
+++ b/dwmkerr.com/layouts/_default/single.html
@@ -17,23 +17,21 @@
   </div>
   {{ end }}
   {{ if eq (.Type | singularize) "post" }}
-  {{ if not (.Param "hideDate") }}
-  <div class="c-article-date">
-    <time datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" | safeHTML }}">
-      {{ .Date.Format "Jan 2, 2006" }}
-    </time>
+  {{ with $.Site.Params.substack }}
+  <div class="p-article__subscribe">
+    <a href="{{ absURL "page/subscribe" }}">Subscribe to get new posts by email</a>
   </div>
   {{ end }}
-  {{ end }}
-  {{ with .Params.discussion }}
+  {{ with $.Params.discussion }}
   <div class="p-article__discussion">
     <a href="{{ . }}" target="_blank" rel="noopener">Discuss on Hacker News / Reddit</a>
   </div>
   {{ end }}
-  {{ if eq (.Type | singularize) "post" }}
-  {{ with .Site.Params.substack }}
-  <div class="p-article__subscribe">
-    <a href="{{ absURL "page/subscribe" }}">Subscribe to get new posts by email</a>
+  {{ if not ($.Param "hideDate") }}
+  <div class="c-article-date">
+    <time datetime="{{ $.Date.Format "2006-01-02T15:04:05Z07:00" | safeHTML }}">
+      {{ $.Date.Format "Jan 2, 2006" }}
+    </time>
   </div>
   {{ end }}
   {{ end }}

--- a/dwmkerr.com/layouts/partials/header.html
+++ b/dwmkerr.com/layouts/partials/header.html
@@ -34,6 +34,13 @@
             </a>
           </li>
           {{ end }}
+          {{ with ($.Param "substack") }}
+          <li class="c-links__item">
+            <a href="/page/subscribe/" title="Subscribe">
+              <svg viewBox="0 0 16 16" class="c-links__icon"><path d="M1 3h14v10H1V3zm0 0l7 5 7-5" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round"/></svg>
+            </a>
+          </li>
+          {{ end }}
         </ul>
       </nav>
     </div>

--- a/dwmkerr.com/static/css/custom.css
+++ b/dwmkerr.com/static/css/custom.css
@@ -69,6 +69,23 @@
   line-height: 1.8;
 }
 
+.p-article__subscribe {
+  margin: 2rem 0;
+  padding: 1.5rem 0;
+  border-top: 1px solid #eee;
+}
+
+.p-article__subscribe p {
+  margin: 0 0 0.5rem 0;
+  color: #666;
+  font-size: 1.4rem;
+}
+
+.p-article__subscribe-frame {
+  width: 100%;
+  height: 150px;
+}
+
 .p-article__discussion {
   margin: 2rem 0;
   padding: 1rem 0;

--- a/dwmkerr.com/static/css/custom.css
+++ b/dwmkerr.com/static/css/custom.css
@@ -76,6 +76,7 @@
 }
 
 .p-article__subscribe a {
+  font-size: 1.6rem;
   font-weight: 500;
 }
 

--- a/dwmkerr.com/static/css/custom.css
+++ b/dwmkerr.com/static/css/custom.css
@@ -71,19 +71,12 @@
 
 .p-article__subscribe {
   margin: 2rem 0;
-  padding: 1.5rem 0;
+  padding: 1rem 0;
   border-top: 1px solid #eee;
 }
 
-.p-article__subscribe p {
-  margin: 0 0 0.5rem 0;
-  color: #666;
-  font-size: 1.4rem;
-}
-
-.p-article__subscribe-frame {
-  width: 100%;
-  height: 150px;
+.p-article__subscribe a {
+  font-weight: 500;
 }
 
 .p-article__discussion {

--- a/dwmkerr.com/static/css/custom.css
+++ b/dwmkerr.com/static/css/custom.css
@@ -73,11 +73,7 @@
   margin: 2rem 0;
   padding: 1rem 0;
   border-top: 1px solid #eee;
-}
-
-.p-article__subscribe a {
-  font-size: 1.6rem;
-  font-weight: 500;
+  font-size: inherit;
 }
 
 .p-article__discussion {


### PR DESCRIPTION
## Summary
- Adds Substack subscribe iframe at the bottom of each blog post
- Configured via `substack` param in `config.toml` (set to `dwmkerr`)
- Minimal styling that fits the existing site design

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 3 no changes — [View all](https://hub.continue.dev/inbox/pr/dwmkerr/dwmkerr.com/68?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->