### PR TITLE
docs: add AI Native DevCon talk on bipolar disorder, dysregulation & AI

### DIFF
--- a/dwmkerr.com/content/page/about.md
+++ b/dwmkerr.com/content/page/about.md
@@ -32,6 +32,7 @@ My journey started with C and C++, writing device drivers, then moved through .N
 
 #### Conference Presentations
 
+- [AI Native DevCon London: Bipolar Disorder, Dysregulation & AI](https://www.youtube.com/watch?v=ACL7_EsfIio) – 2026
 - [The Changelog: Laws for hackers to live by](https://changelog.com/podcast/403) – Podcast, 2020
 - [VoxxedDays Singapore: What does DevOps culture mean for engineers?](https://www.youtube.com/watch?v=oHhnq-3Q66U) – 2018
 - [DevOpsDays Jakarta: The Universe as Code](https://www.slideshare.net/DevOpsDaysJKT/the-universe-as-code-dave-kerr) – 2018

--- a/dwmkerr.com/content/page/conferences.md
+++ b/dwmkerr.com/content/page/conferences.md
@@ -1,0 +1,20 @@
+---
+author: Dave Kerr
+date: "2026-04-01"
+description: "Conference talks, webinars and speaking engagements."
+draft: false
+slug: conferences
+title: Conferences
+---
+
+Conference talks, webinars and speaking engagements.
+
+| Event | Location | Topic | Links |
+|-------|----------|-------|-------|
+| [NearForm ImpactTalks 2026](https://nearform.com/ai-native-engineering-session/) | Online, February 2026 | Copilot isn't a strategy – Agentic Engineering vs Agentic Software | [Recording](https://lnkd.in/dQiUqAsZ) |
+| [DevOpsDays Jakarta 2018](https://www.devopsdays.org/events/2018-jakarta/) | Jakarta, April 2018 | The Universe As Code | [SpeakerDeck](https://www.slideshare.net/DevOpsDaysJKT/the-universe-as-code-dave-kerr) |
+| [JPMC DevOps Event](https://www.devopsdays.org/events/2018-jakarta/) | Singapore, April 2018 | | |
+| [Serverless Summit 2017](https://inserverless.com) | Bangalore, October 2017 | Build a Chatbot in 10 Minutes | [SpeakerDeck](https://speakerdeck.com/dwmkerr/build-a-chatbot-in-10-minutes) |
+| [DevOpsDays Singapore 2017](https://www.devopsdays.org/events/2017-singapore/) | Singapore, 2017 | Monoliths to Microservices – Practical Tips for CI/CD and DevOps | [Video](https://youtu.be/NVb7aljfKYo?t=6657) · [SlideShare](https://www.slideshare.net/secret/4hIkPtQDLg1Drg) · [SpeakerDeck](https://speakerdeck.com/dwmkerr/monoliths-to-microservices-practical-tips-for-ci-cd-and-devops-in-the-microservices-world) |
+| McKinsey DevOps Days 2017 | Amsterdam, 2017 | Breaking Monoliths – Moving a Bank from Monoliths to Microservices | |
+| [JSChannel 2016](http://2016.jschannel.com/) | Bangalore, 2016 | Effective Node.js Debugging | [YouTube](https://www.youtube.com/watch?v=-iCygy2wGpM&t=69s) |

--- a/dwmkerr.com/content/page/conferences.md
+++ b/dwmkerr.com/content/page/conferences.md
@@ -11,6 +11,7 @@ Conference talks, webinars and speaking engagements.
 
 | Event | Location | Topic | Links |
 |-------|----------|-------|-------|
+| [AI Native DevCon London 2026](https://tessl.io/devcon) | London, June 2026 | Bipolar Disorder, Dysregulation & AI | [Talk](https://www.youtube.com/watch?v=ACL7_EsfIio) · [Short](https://www.youtube.com/watch?v=u3yaHmlprJY) |
 | [NearForm ImpactTalks 2026](https://nearform.com/ai-native-engineering-session/) | Online, February 2026 | Copilot isn't a strategy – Agentic Engineering vs Agentic Software | [Recording](https://lnkd.in/dQiUqAsZ) |
 | [DevOpsDays Jakarta 2018](https://www.devopsdays.org/events/2018-jakarta/) | Jakarta, April 2018 | The Universe As Code | [SpeakerDeck](https://www.slideshare.net/DevOpsDaysJKT/the-universe-as-code-dave-kerr) |
 | [JPMC DevOps Event](https://www.devopsdays.org/events/2018-jakarta/) | Singapore, April 2018 | | |

--- a/dwmkerr.com/content/post/2026/bipolar-dysregulation-and-ai/index.md
+++ b/dwmkerr.com/content/post/2026/bipolar-dysregulation-and-ai/index.md
@@ -1,0 +1,38 @@
+---
+author: Dave Kerr
+type: posts
+date: "2026-06-09"
+title: "Bipolar Disorder, Dysregulation & AI"
+description: "My AI Native DevCon London talk on what living with bipolar disorder taught me about regulation, and how those same patterns show up in AI-native engineering."
+slug: bipolar-dysregulation-and-ai
+draft: false
+categories:
+- "ai"
+- "mental-health"
+tags:
+- "ai"
+- "agentic-engineering"
+- "mental-health"
+- "conferences"
+---
+
+At AI Native DevCon London 2026 I gave a talk about bipolar disorder, what living with it has forced me to learn, and how the same patterns keep showing up in the way we work with AI.
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/ACL7_EsfIio" frameborder="0" allowfullscreen></iframe>
+
+## What the talk is about
+
+Managing bipolar disorder is largely about regulation. There are things that push your state around - sleep, rhythm, stress, people, substances - and the work is to spot the ones that destabilise you (dysregulators) and counterbalance them with the ones that steady you (regulators).
+
+This is hard partly because the condition can come with compromised interoception - your sense of your own internal state, the thing you'd normally rely on to tell where you are. When that's unreliable, you can't fully trust your own read on yourself, so you lean on what's around you instead.
+
+Once you've spent years pathologising your own behaviour, looking for what's adaptive and what isn't, you start to recognise the same shapes elsewhere. Over the last few years I've seen a lot of them in AI-native engineering:
+
+- Transformative shifts in core beliefs
+- Addiction
+- Grandiosity
+- Attentional fragmentation
+- Pressured speaking
+- Maladaptive creativity
+
+The counterweights - the regulators for each of these - are described in the talk.


### PR DESCRIPTION
## Summary
- Add blog post for AI Native DevCon London 2026 talk "Bipolar Disorder, Dysregulation & AI" with embedded talk video
- Add talk to top of conferences page (Talk + Short links)
- Add talk as first bullet under Conference Presentations on About page